### PR TITLE
FunctionCommentSpacing - space after the fn arrow

### DIFF
--- a/DatacodeStandard/Sniffs/Functions/ShortFunctionSpacingSniff.php
+++ b/DatacodeStandard/Sniffs/Functions/ShortFunctionSpacingSniff.php
@@ -40,6 +40,7 @@ class ShortFunctionSpacingSniff implements Sniff {
 	 *
 	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
 	 * @param integer $stackPtr The position of the current token in the stack passed in $tokens.
+	 * @param string $afterType The type char the whitespace should be after to display in the error
 	 *
 	 * @return void
 	 */

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "datacodetech/phpcs-ruleset",
-	"version": "2.2.0",
+	"version": "2.3",
 	"type": "library",
 	"license": "MIT",
 	"description": "phpcs ruleset used for all PHP projects",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "datacodetech/phpcs-ruleset",
-	"version": "2.3",
+	"version": "2.2.1",
 	"type": "library",
 	"license": "MIT",
 	"description": "phpcs ruleset used for all PHP projects",


### PR DESCRIPTION
turns `=>(` and `=>{` into `=> (` and `=> {`